### PR TITLE
Add double relay support

### DIFF
--- a/lib/features/power/implementations/autokit-relay/index.ts
+++ b/lib/features/power/implementations/autokit-relay/index.ts
@@ -18,13 +18,13 @@ export class AutokitRelay implements Power {
     // Power on the DUT
     async on(voltage?: number): Promise<void> {
         console.log(`Powering on DUT...`)
-        await this.relay.setState(1, true);
+        await this.relay.setState(0, true);
     }
 
     // Power off the DUT
     async off(): Promise<void> {
         console.log(`Powering off DUT...`)
-        await this.relay.setState(1, false);
+        await this.relay.setState(0, false);
     }
 
     async getState(): Promise<string> {


### PR DESCRIPTION
In order for the double relay to work correctly, we must use the 0 index to turn both of them on/off at the same time.

Change-type: minor
Signed-off-by: Pedro Henrique Kopper <pedro.kopper@balena.io>