### PR TITLE
allow relay to have NC configuration

### DIFF
--- a/lib/features/power/implementations/autokit-relay/index.ts
+++ b/lib/features/power/implementations/autokit-relay/index.ts
@@ -5,9 +5,11 @@ const USBRelay = require("@balena/usbrelay");
 export class AutokitRelay implements Power {
     private relayId: string
     private relay: any
+    private conn: boolean
     constructor(){
         this.relayId = 'HW348_1'
         this.relay = new USBRelay(); //gets the first connected relay
+        this.conn = (process.env.USB_RELAY_CONN === 'NC') ? false: true // if the user specifies they have set up the connection to be NC
     }
 
     async setup(): Promise<void> {
@@ -18,13 +20,13 @@ export class AutokitRelay implements Power {
     // Power on the DUT
     async on(voltage?: number): Promise<void> {
         console.log(`Powering on DUT...`)
-        await this.relay.setState(0, true);
+        await this.relay.setState(0, this.conn);
     }
 
     // Power off the DUT
     async off(): Promise<void> {
         console.log(`Powering off DUT...`)
-        await this.relay.setState(0, false);
+        await this.relay.setState(0, !this.conn);
     }
 
     async getState(): Promise<string> {


### PR DESCRIPTION
Allow for cases where the user has a relay set up with NC instead of NO - the main use of this feature is for debugging right now

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>